### PR TITLE
conversations.getFromUser() conversation id fix

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -32,6 +32,14 @@ module.exports = function(config) {
   this.version = config.version || '1.0';
   this.timeout = config.timeout || 10000;
 
+  if (config.agent) {
+    if (config.agent instanceof https.Agent) this.agent = config.agent;
+    else throw new Error(utils.i18n.layerapi.agent);
+  } 
+  else if (config.agentOptions) {
+    this.agent = new https.Agent(config.agentOptions);
+  }
+
   // expose request methods
   API.methods.forEach(function(method) {
     this[method] = request.bind(this, method);
@@ -57,23 +65,31 @@ function request(method, params, callback) {
 
   if (params.dedupe) headers['If-None-Match'] = params.dedupe;
 
-  var req = https.request({
+  var options = {
     host: API.host,
     port: API.port,
     path: API.prefix + this.appId + params.path,
     method: method.toUpperCase(),
     headers: headers
-  });
+  }
+
+  if (this.agent) options.agent = this.agent;
+
+  var req = https.request(options);
 
   req.setTimeout(this.timeout, timeout.bind(this, req, callback));
   req.on('error', error.bind(this, req, callback));
   req.on('response', response.bind(this, callback));
 
   req.on('socket', function(socket) {
-    socket.on(('secureConnect'), function() {
+    var write = function() {
       if (params.body) req.write(JSON.stringify(params.body));
       req.end();
-    });
+    }
+    // reusing connection when using keepAlive agent
+    if (socket.authorized) write();
+    // TODO: should also check if authorized here and throw if not
+    else socket.on('secureConnect', function() { write(); })      
   });
 }
 

--- a/lib/resources/conversations.js
+++ b/lib/resources/conversations.js
@@ -59,7 +59,7 @@ module.exports = function(request) {
       utils.debug('Conversation getFromUser: ' + userId);
 
       request.get({
-        path: '/users/' + querystring.escape(userId) + '/conversations' + (conversationUUID ? '/' + conversationId : '')
+        path: '/users/' + querystring.escape(userId) + '/conversations' + (conversationUUID ? '/' + conversationUUID : '')
       }, callback);
     },
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -62,7 +62,8 @@ exports.debug = function(val) {
 exports.i18n = {
   layerapi: {
     token: 'You need to pass a valid `token` to constructor',
-    appId: 'You need to pass a valid `appId` to constructor'
+    appId: 'You need to pass a valid `appId` to constructor',
+    agent: 'Constructor option `agent` needs to be an instance of https.Agent'
   },
   conversations: {
     body: 'Conversation body is required',


### PR DESCRIPTION
1. conversations.getFromUser() now works with full conversation id, fixes #3
2. added 2 options to layer-api constructor: 
  - agentOptions : creates a https.Agent specific to the created instance with  given options
  - agent : allows to pass a custom https.Agent instance so that it can be shared with other code. If `agent` option is provided `agentOptions` are ignored