### PR TITLE
Breaking method name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ layer.conversations.create({participants: ['abcd']}, function(err, res) {
   var cid = res.body.id;
 
   // Send a Message
-  layer.messages.sendTexFromUser(cid, 'abcd', 'Hello, World!', function(err, res) {
+  layer.messages.sendTextFromUser(cid, 'abcd', 'Hello, World!', function(err, res) {
     console.log(err || res.body);
   });
 });
@@ -220,7 +220,7 @@ Same as send a message above but including [de-duplicating](https://developer.la
 
 ---------------------------------------
 
-### messages.sendTexFromUser(cid, userId, text, [callback])
+### messages.sendTextFromUser(cid, userId, text, [callback])
 
 Shorthand method for sending a plain text Message by providing `userId` and `text`.
 
@@ -233,7 +233,7 @@ Shorthand method for sending a plain text Message by providing `userId` and `tex
 
 ---------------------------------------
 
-### messages.sendTexFromName(cid, name, text, [callback])
+### messages.sendTextFromName(cid, name, text, [callback])
 
 Shorthand method for sending a plain text Message by providing `name` and `text`.
 

--- a/lib/resources/messages.js
+++ b/lib/resources/messages.js
@@ -36,7 +36,7 @@ module.exports = function(request) {
      * @param  {String}   text           Message text
      * @param  {Function} callback       Callback function
      */
-    sendTexFromUser: function(conversationId, userId, text, callback) {
+    sendTextFromUser: function(conversationId, userId, text, callback) {
       send(null, conversationId, utils.messageText('user_id', userId, text), callback);
     },
 
@@ -48,7 +48,7 @@ module.exports = function(request) {
      * @param  {String}   text           Message text
      * @param  {Function} callback       Callback function
      */
-    sendTexFromName: function(conversationId, name, text, callback) {
+    sendTextFromName: function(conversationId, name, text, callback) {
       send(null, conversationId, utils.messageText('name', name, text), callback);
     }
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "layer-api",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Node.js library, which provides a wrapper for the Layer Platform API",
   "publishConfig": {
     "registry": "http://registry.npmjs.org/"

--- a/test/integration/messages.spec.js
+++ b/test/integration/messages.spec.js
@@ -85,9 +85,9 @@ describe('Messages operations', function() {
     });
   });
 
-  describe('Sending a message to a conversation using sendTexFromName', function() {
+  describe('Sending a message to a conversation using sendTextFromName', function() {
     it('should return an error', function(done) {
-      layerAPI.messages.sendTexFromName(conversationId, message.sender.name, 'hello world', function(err, res) {
+      layerAPI.messages.sendTextFromName(conversationId, message.sender.name, 'hello world', function(err, res) {
         should.not.exist(err);
         should.exist(res);
 
@@ -99,9 +99,9 @@ describe('Messages operations', function() {
     });
   });
 
-  describe('Sending a message to a conversation using sendTexFromUser', function() {
+  describe('Sending a message to a conversation using sendTextFromUser', function() {
     it('should return an error', function(done) {
-      layerAPI.messages.sendTexFromUser(conversationId, participants[0], 'hello world2', function(err, res) {
+      layerAPI.messages.sendTextFromUser(conversationId, participants[0], 'hello world2', function(err, res) {
         should.not.exist(err);
         should.exist(res);
 

--- a/test/layerapi.spec.js
+++ b/test/layerapi.spec.js
@@ -22,8 +22,8 @@ describe('Layer API constructor', function() {
 
       should(typeof layerApi.messages.send).be.eql('function');
       should(typeof layerApi.messages.sendDedupe).be.eql('function');
-      should(typeof layerApi.messages.sendTexFromUser).be.eql('function');
-      should(typeof layerApi.messages.sendTexFromUser).be.eql('function');
+      should(typeof layerApi.messages.sendTextFromUser).be.eql('function');
+      should(typeof layerApi.messages.sendTextFromUser).be.eql('function');
 
       should(typeof layerApi.announcements.send).be.eql('function');
       should(typeof layerApi.announcements.sendDedupe).be.eql('function');

--- a/test/messages.spec.js
+++ b/test/messages.spec.js
@@ -66,7 +66,7 @@ describe('Messages operations', function() {
     });
   });
 
-  describe('Sending a message to a conversation using sendTexFromUser', function() {
+  describe('Sending a message to a conversation using sendTextFromUser', function() {
     nock('https://api.layer.com')
       .post('/apps/' + fixtures.appId + '/conversations/' + fixtures.conversations.uuid + '/messages')
       .reply(201, fixtures.messages.success);
@@ -74,7 +74,7 @@ describe('Messages operations', function() {
     it('should return a message object', function(done) {
       var userId = 'abcd';
       var text = 'testing 123';
-      layerAPI.messages.sendTexFromUser(fixtures.conversations.uuid, userId, text, function(err, res) {
+      layerAPI.messages.sendTextFromUser(fixtures.conversations.uuid, userId, text, function(err, res) {
         should.not.exist(err);
         should.exist(res);
 
@@ -86,7 +86,7 @@ describe('Messages operations', function() {
     });
   });
 
-  describe('Sending a message to a conversation using sendTexFromName', function() {
+  describe('Sending a message to a conversation using sendTextFromName', function() {
     nock('https://api.layer.com')
       .post('/apps/' + fixtures.appId + '/conversations/' + fixtures.conversations.uuid + '/messages')
       .reply(201, fixtures.messages.success);
@@ -94,7 +94,7 @@ describe('Messages operations', function() {
     it('should return a message object', function(done) {
       var name = 'The System';
       var text = 'testing 123';
-      layerAPI.messages.sendTexFromName(fixtures.conversations.uuid, name, text, function(err, res) {
+      layerAPI.messages.sendTextFromName(fixtures.conversations.uuid, name, text, function(err, res) {
         should.not.exist(err);
         should.exist(res);
 


### PR DESCRIPTION
Fixing a typo in two method names for Conversations resource:

 - sendTexFromUser -> sendTextFromUser
 - sendTexFromName -> sendTextFromName